### PR TITLE
chore: add project hygiene files (license, contributing, conduct, changelog, gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,42 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.so
+.build/
+.eggs/
+*.egg-info/
+.dist/
+
+# Virtual env
+.env/
+.venv/
+venv/
+ENV/
+
+# Env files / secrets
+*.env
+!.example.env
+
+# Logs & outputs
+logs/
+outputs/*.tmp
+
+# IDE
+.vscode/
+.idea/
+.DS_Store
+
+# Tests / coverage
+.pytest_cache/
+.coverage*
+htmlcov/
+
+# Node (web dir)
+node_modules/
+web/node_modules/
+web/dist/
+
+# Misc
+*.swp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented here.
+
+The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and adheres to semantic versioning when releases begin.
+
+## [Unreleased]
+### Added
+- Initial project hygiene files: LICENSE, CONTRIBUTING, CODE_OF_CONDUCT, CHANGELOG.
+- Expanded README (features, quick start, roadmap).
+
+### Planned
+- CI workflow for tests & lint
+- Plugin auto-discovery improvements
+- Structured JSON response mode

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,27 @@
+# Code of Conduct
+
+We aim to foster an open, welcoming, and harassment‑free community.
+
+## Standards
+Examples of positive behavior:
+- Using inclusive, respectful language
+- Being considerate of differing viewpoints
+- Accepting constructive feedback gracefully
+- Focusing on what is best for the project and community
+
+Unacceptable behavior includes:
+- Harassment, discrimination, or derogatory comments
+- Trolling or insulting remarks
+- Publishing others' private information
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+Report incidents to the maintainers via GitHub issues or direct contact. Reports will be reviewed and addressed promptly and confidentially.
+
+Project maintainers may remove, edit, or reject contributions not aligned with this Code.
+
+## Scope
+This Code applies within all project spaces and in public spaces when representing the project.
+
+## Attribution
+Inspired by Contributor Covenant.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing Guide
+
+Thanks for your interest in improving PiControl Agent!
+
+## Quick Start
+1. Fork & clone the repo.
+2. Create a branch: `git checkout -b feature/my-change`.
+3. Create a virtual environment & install deps: `pip install -r requirements.txt`.
+4. Run tests: `pytest -q`.
+5. Make changes (add tests for new logic / tools).
+6. Ensure `pytest` passes and no obvious lint errors (Black/Flake8 optional future).
+7. Commit using conventional commits (e.g. `feat: add gpio toggle tool`).
+8. Open a Pull Request and fill out the description template.
+
+## Adding a Plugin Tool
+- Place a new Python file in `llamatrama_agent/plugins/`.
+- Expose one or more functions with clear docstrings (inputs / outputs / side effects).
+- Keep network or long-running operations minimal; stream output if future streaming is added.
+- Add at least one test demonstrating use (or mock the SSH layer where applicable).
+
+## Tests
+- Core tests live under `tests/`.
+- If adding SSH behavior, mock network side effects.
+- Prefer small, deterministic tests.
+
+## Documentation
+- Update `README.md` if user-facing behavior changes.
+- Add examples where helpful.
+
+## Style
+- Python 3.12+
+- Aim for clarity over cleverness.
+
+## Code of Conduct
+Participation is governed by `CODE_OF_CONDUCT.md`.
+
+## License
+By contributing you agree your work is licensed under the MIT License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 PiControl Agent Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
This PR adds standard open-source hygiene documents:

- MIT `LICENSE`
- Root `.gitignore` (Python, Node, env, logs)
- `CONTRIBUTING.md` with guidelines and plugin section
- `CODE_OF_CONDUCT.md`
- `CHANGELOG.md` (initial Unreleased section)

Follow-ups proposed:
- Add CI workflow (pytest) badge + status
- Add screenshot / demo GIF
- Tag first release once stable (v0.1.0)

Let me know if you’d like a different license or additional sections.

## Summary by Sourcery

Add standard open-source project hygiene files

Documentation:
- Add LICENSE to specify the MIT license
- Add CONTRIBUTING.md and CODE_OF_CONDUCT.md to define contribution process and community standards
- Add CHANGELOG.md with initial Unreleased section and project overview
- Add root .gitignore for Python, Node, environment, and logs